### PR TITLE
Update script link on default.html

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -40,6 +40,6 @@
 			{{ content }}
 		</div>
 	</div>
-	<script src="script/script.js"></script>
+	<script src="https://bcngeeks.github.io/Geekateca/script/script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
# Summary

I've modifyed the script link.

## Details

Previously, the script was linked as "script/script.js", now it has an absolute route, meaning "https://......."

## References

none

## Select the team

- [ ] HTML
- [ ] CSS
- [X] GitHub

## Checks

- [X] Tested Changes
